### PR TITLE
feat: exposes `dlqProps` and `topicProps` for customising constructs on a granular level

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
   - [`messagingProviders`](#messagingproviders)
     - [1. `EmailProvider`](#1-emailprovider)
     - [2. `SlackProvider`](#2-slackprovider)
+  - [`dlqProps`](#dlqprops)
+  - [`alarmProps`](#alarmprops)
+  - [`topicProps`](#topicprops)
 - [Deployed Infrastructure](#deployed-infrastructure)
 - [Setting up Email notifications](#setting-up-email-notifications)
   - [`EmailProvider`](#emailprovider)
@@ -163,6 +166,19 @@ Sets up Slack Messaging
 For info on setting this up see:
 
 [Setting Up Slack Notifications](#setting-up-slack-notifications)
+
+## `dlqProps`
+
+The standard SQS Queue Props which can be used to customise the deployed DLQ. 
+The value of this property will be overriden if the queueProps.deadLetterQueue is provided.
+
+## `alarmProps`
+
+The standard CloudWatch Alarm props which can be used to customise the deployed alarm.
+
+## `topicProps`
+
+The standard SNS Topic properties which can be used to customise the deployed topic.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
     - [1. `EmailProvider`](#1-emailprovider)
     - [2. `SlackProvider`](#2-slackprovider)
   - [`dlqProps`](#dlqprops)
-  - [`alarmProps`](#alarmprops)
   - [`topicProps`](#topicprops)
 - [Deployed Infrastructure](#deployed-infrastructure)
 - [Setting up Email notifications](#setting-up-email-notifications)
@@ -171,10 +170,6 @@ For info on setting this up see:
 
 The standard SQS Queue Props which can be used to customise the deployed DLQ. 
 The value of this property will be overriden if the queueProps.deadLetterQueue is provided.
-
-## `alarmProps`
-
-The standard CloudWatch Alarm props which can be used to customise the deployed alarm.
 
 ## `topicProps`
 

--- a/src/monitoredQueue.ts
+++ b/src/monitoredQueue.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
   Alarm,
   AlarmProps,
@@ -5,14 +6,16 @@ import {
 } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Architecture, Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
-import { Topic, TopicProps } from 'aws-cdk-lib/aws-sns';
+import {
+  Topic,
+  TopicProps,
+} from 'aws-cdk-lib/aws-sns';
 import {
   EmailSubscription,
   LambdaSubscription,
 } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { DeadLetterQueue, Queue, QueueProps } from 'aws-cdk-lib/aws-sqs';
 import { Construct } from 'constructs';
-import * as path from 'path';
 
 export interface IMessagingProvider {
   deployProvider(scope: Construct, topic: Topic): void;
@@ -47,7 +50,7 @@ export class SlackProvider implements IMessagingProvider {
       topic,
       this.slackToken,
       this.slackChannel,
-      this.name
+      this.name,
     );
   }
 }
@@ -146,7 +149,7 @@ export class MonitoredQueue extends Construct {
         'DeadLetterQueue',
         props.dlqProps || {
           queueName: `${props.queueProps.queueName}-dlq`,
-        }
+        },
       ),
       maxReceiveCount: props.maxReceiveCount || 3,
     };
@@ -170,7 +173,7 @@ export class MonitoredQueue extends Construct {
         threshold: props.messageThreshold || 5,
         evaluationPeriods: props.evaluationThreshold || 1,
         treatMissingData: TreatMissingData.NOT_BREACHING,
-      }
+      },
     );
 
     this.alarm = alarm;
@@ -180,7 +183,7 @@ export class MonitoredQueue extends Construct {
       'Topic',
       props.topicProps || {
         topicName: `${deadLetterQueue.queue.queueName}-alarm-topic`,
-      }
+      },
     );
 
     this.topic = topic;
@@ -209,7 +212,7 @@ function addSlackNotificationDestination(
   topic: Topic,
   slackToken: string,
   slackChannel: string,
-  name: string
+  name: string,
 ) {
   const slackListener = new Function(scope, 'SlackListenerLambda' + name, {
     runtime: Runtime.NODEJS_18_X,

--- a/src/monitoredQueue.ts
+++ b/src/monitoredQueue.ts
@@ -1,14 +1,18 @@
-import * as path from 'path';
-import { Alarm, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
+import {
+  Alarm,
+  AlarmProps,
+  TreatMissingData,
+} from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Architecture, Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
-import { Topic } from 'aws-cdk-lib/aws-sns';
+import { Topic, TopicProps } from 'aws-cdk-lib/aws-sns';
 import {
   EmailSubscription,
   LambdaSubscription,
 } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { DeadLetterQueue, Queue, QueueProps } from 'aws-cdk-lib/aws-sqs';
 import { Construct } from 'constructs';
+import * as path from 'path';
 
 export interface IMessagingProvider {
   deployProvider(scope: Construct, topic: Topic): void;
@@ -43,7 +47,7 @@ export class SlackProvider implements IMessagingProvider {
       topic,
       this.slackToken,
       this.slackChannel,
-      this.name,
+      this.name
     );
   }
 }
@@ -62,24 +66,28 @@ export class EmailProvider implements IMessagingProvider {
 }
 
 export interface IMonitoredQueueProps {
-  /** The standard properties of the SQS Queue Construct
+  /**
+   * The standard properties of the SQS Queue Props to set the properties for the deployed queue
    * @required
    */
   readonly queueProps: QueueProps;
 
-  /** The number of times a message can be unsuccesfully dequeued before being moved to the dead-letter queue.
+  /**
+   * The number of times a message can be unsuccesfully dequeued before being moved to the dead-letter queue.
    * @default 3
    * @optional
    */
   readonly maxReceiveCount?: number;
 
-  /** The threshold for the amount of messages that are in the DLQ which trigger the alarm
+  /**
+   * The threshold for the amount of messages that are in the DLQ which trigger the alarm
    * @default 5
    * @optional
    */
   readonly messageThreshold?: number;
 
-  /** The number of periods over which data is compared to the specified threshold.
+  /**
+   * The number of periods over which data is compared to the specified threshold.
    * @default 1
    * @optional
    */
@@ -90,6 +98,22 @@ export interface IMonitoredQueueProps {
    * @optional
    */
   readonly messagingProviders?: IMessagingProvider[];
+
+  /**
+   * The standard SQS Queue Props which can be used to customise the deployed DLQ.
+   * The value of this property will be overriden if the queueProps.deadLetterQueue is provided.
+   */
+  readonly dlqProps?: QueueProps;
+
+  /**
+   * The standard CloudWatch Alarm props which can be used to customise the deployed alarm.
+   */
+  readonly alarmProps?: AlarmProps;
+
+  /**
+   * The standard SNS Topic properties which can be used to customise the deployed topic.
+   */
+  readonly topicProps?: TopicProps;
 }
 
 export class MonitoredQueue extends Construct {
@@ -116,14 +140,16 @@ export class MonitoredQueue extends Construct {
   constructor(scope: Construct, id: string, props: IMonitoredQueueProps) {
     super(scope, id);
 
-    const deadLetterQueue = props.queueProps.deadLetterQueue
-      ? props.queueProps.deadLetterQueue
-      : {
-        queue: new Queue(this, 'DeadLetterQueue', {
+    const deadLetterQueue = props.queueProps.deadLetterQueue || {
+      queue: new Queue(
+        this,
+        'DeadLetterQueue',
+        props.dlqProps || {
           queueName: `${props.queueProps.queueName}-dlq`,
-        }),
-        maxReceiveCount: props.maxReceiveCount || 3,
-      };
+        }
+      ),
+      maxReceiveCount: props.maxReceiveCount || 3,
+    };
 
     this.deadLetterQueue = deadLetterQueue;
 
@@ -134,19 +160,28 @@ export class MonitoredQueue extends Construct {
 
     this.queue = queue;
 
-    const alarm = new Alarm(this, 'DLQ-Alarm', {
-      alarmName: `${deadLetterQueue.queue.queueName}-alarm`,
-      metric: deadLetterQueue.queue.metricApproximateNumberOfMessagesVisible(),
-      threshold: props.messageThreshold || 5,
-      evaluationPeriods: props.evaluationThreshold || 1,
-      treatMissingData: TreatMissingData.NOT_BREACHING,
-    });
+    const alarm = new Alarm(
+      this,
+      'DLQ-Alarm',
+      props.alarmProps || {
+        alarmName: `${deadLetterQueue.queue.queueName}-alarm`,
+        metric:
+          deadLetterQueue.queue.metricApproximateNumberOfMessagesVisible(),
+        threshold: props.messageThreshold || 5,
+        evaluationPeriods: props.evaluationThreshold || 1,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      }
+    );
 
     this.alarm = alarm;
 
-    const topic = new Topic(this, 'Topic', {
-      topicName: `${deadLetterQueue.queue.queueName}-alarm-topic`,
-    });
+    const topic = new Topic(
+      this,
+      'Topic',
+      props.topicProps || {
+        topicName: `${deadLetterQueue.queue.queueName}-alarm-topic`,
+      }
+    );
 
     this.topic = topic;
 
@@ -174,7 +209,7 @@ function addSlackNotificationDestination(
   topic: Topic,
   slackToken: string,
   slackChannel: string,
-  name: string,
+  name: string
 ) {
   const slackListener = new Function(scope, 'SlackListenerLambda' + name, {
     runtime: Runtime.NODEJS_18_X,

--- a/test/__snapshots__/monitoredQueue.test.ts.snap
+++ b/test/__snapshots__/monitoredQueue.test.ts.snap
@@ -266,6 +266,294 @@ exports[`MonitoredQueue should create a monitored queue with a custom DLQ 1`] = 
 }
 `;
 
+exports[`MonitoredQueue should create a monitored queue with a custom DLQ using \`dlqProps\` 1`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "testDLQAlarmFF94B263": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "testTopic20AA7407",
+          },
+        ],
+        "AlarmName": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Fn::GetAtt": [
+                  "testDeadLetterQueueA5F7D72D",
+                  "QueueName",
+                ],
+              },
+              "-alarm",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "testDeadLetterQueueA5F7D72D",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": [
+          {
+            "Ref": "testTopic20AA7407",
+          },
+        ],
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "testDeadLetterQueueA5F7D72D": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "custom-dlq-name",
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "testDeadLetterQueuePolicy14C080A7": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sqs:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testDeadLetterQueueA5F7D72D",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Queues": [
+          {
+            "Ref": "testDeadLetterQueueA5F7D72D",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
+    },
+    "testQueueA1A031F3": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "test",
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "testDeadLetterQueueA5F7D72D",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 3,
+        },
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "testTopic20AA7407": {
+      "Properties": {
+        "TopicName": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Fn::GetAtt": [
+                  "testDeadLetterQueueA5F7D72D",
+                  "QueueName",
+                ],
+              },
+              "-alarm-topic",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`MonitoredQueue should create a monitored queue with a custom Topic using \`topicProps\` 1`] = `
+{
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "testDLQAlarmFF94B263": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "testTopic20AA7407",
+          },
+        ],
+        "AlarmName": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Fn::GetAtt": [
+                  "testDeadLetterQueueA5F7D72D",
+                  "QueueName",
+                ],
+              },
+              "-alarm",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "testDeadLetterQueueA5F7D72D",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": [
+          {
+            "Ref": "testTopic20AA7407",
+          },
+        ],
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "testDeadLetterQueueA5F7D72D": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "test-dlq",
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "testQueueA1A031F3": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "QueueName": "test",
+        "RedrivePolicy": {
+          "deadLetterTargetArn": {
+            "Fn::GetAtt": [
+              "testDeadLetterQueueA5F7D72D",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 3,
+        },
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "testTopic20AA7407": {
+      "Properties": {
+        "ContentBasedDeduplication": true,
+        "FifoTopic": true,
+        "TopicName": "test-topic-name.fifo",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`MonitoredQueue should create a monitored queue with a lambda SNS listener and Lambda Subscription 1`] = `
 {
   "Parameters": {

--- a/test/monitoredQueue.test.ts
+++ b/test/monitoredQueue.test.ts
@@ -49,24 +49,8 @@ describe('MonitoredQueue', () => {
         queueName: 'test',
       },
       dlqProps: {
-        queueName: `custom-dlq-name`,
+        queueName: 'custom-dlq-name',
         enforceSSL: true,
-      }
-    });
-
-    const template = Template.fromStack(stack);
-    template.resourceCountIs('AWS::SQS::Queue', 2);
-    template.resourceCountIs('AWS::CloudWatch::Alarm', 1);
-    template.resourceCountIs('AWS::Lambda::Function', 0);
-    template.resourceCountIs('AWS::SNS::Subscription', 0);
-    expect(template.toJSON()).toMatchSnapshot();
-  });
-
-  test('should create a monitored queue with a custom Alarm using `alarmProps`', () => {
-    const stack = new Stack();
-    new MonitoredQueue(stack, 'test', {
-      queueProps: {
-        queueName: 'test',
       },
     });
 
@@ -85,9 +69,10 @@ describe('MonitoredQueue', () => {
         queueName: 'test',
       },
       topicProps: {
-        topicName: "test-topic-name",
-        
-      }
+        fifo: true,
+        topicName: 'test-topic-name',
+        contentBasedDeduplication: true,
+      },
     });
 
     const template = Template.fromStack(stack);

--- a/test/monitoredQueue.test.ts
+++ b/test/monitoredQueue.test.ts
@@ -42,6 +42,62 @@ describe('MonitoredQueue', () => {
     expect(template.toJSON()).toMatchSnapshot();
   });
 
+  test('should create a monitored queue with a custom DLQ using `dlqProps`', () => {
+    const stack = new Stack();
+    new MonitoredQueue(stack, 'test', {
+      queueProps: {
+        queueName: 'test',
+      },
+      dlqProps: {
+        queueName: `custom-dlq-name`,
+        enforceSSL: true,
+      }
+    });
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::SQS::Queue', 2);
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 1);
+    template.resourceCountIs('AWS::Lambda::Function', 0);
+    template.resourceCountIs('AWS::SNS::Subscription', 0);
+    expect(template.toJSON()).toMatchSnapshot();
+  });
+
+  test('should create a monitored queue with a custom Alarm using `alarmProps`', () => {
+    const stack = new Stack();
+    new MonitoredQueue(stack, 'test', {
+      queueProps: {
+        queueName: 'test',
+      },
+    });
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::SQS::Queue', 2);
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 1);
+    template.resourceCountIs('AWS::Lambda::Function', 0);
+    template.resourceCountIs('AWS::SNS::Subscription', 0);
+    expect(template.toJSON()).toMatchSnapshot();
+  });
+
+  test('should create a monitored queue with a custom Topic using `topicProps`', () => {
+    const stack = new Stack();
+    new MonitoredQueue(stack, 'test', {
+      queueProps: {
+        queueName: 'test',
+      },
+      topicProps: {
+        topicName: "test-topic-name",
+        
+      }
+    });
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::SQS::Queue', 2);
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 1);
+    template.resourceCountIs('AWS::Lambda::Function', 0);
+    template.resourceCountIs('AWS::SNS::Subscription', 0);
+    expect(template.toJSON()).toMatchSnapshot();
+  });
+
   test('should create a monitored queue with an email subscription', () => {
     const stack = new Stack();
     new MonitoredQueue(stack, 'test', {
@@ -96,4 +152,5 @@ describe('MonitoredQueue', () => {
     template.resourceCountIs('AWS::SNS::Subscription', 3);
     expect(template.toJSON()).toMatchSnapshot();
   });
+
 });


### PR DESCRIPTION
Fixes #89
- Adds `dlqProps` for customising the SQS DLQ.
 
Fixes #90
- Adds `topicProps` for customising SNS Topic.
- Unfortunately the `enforceSSL` flag is not supported in the project's `aws-cdk-lib`.
- The issue will be kept open until and added to the backlog.